### PR TITLE
Export all symbols on Windows for the path string conversion functions

### DIFF
--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -154,3 +154,8 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR "${CMAKE_SYSTEM_NAME}" MATCHES "L
         -pthread
     )
 endif()
+
+# MSVC linker options
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()


### PR DESCRIPTION
LuaVis uses the path string conversion functions defined in source/windows/FileNameConversions.cpp. These files are not marked for export and consequently are not added to the resulting DLL file on Windows.

I added to the CMake file the flag for exporting all symbols, thus making available these functions in the created library.